### PR TITLE
Fix : config always parsed even if cache is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - wget http://getcomposer.org/composer.phar
   - php composer.phar install --dev
 

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Builder.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Builder.php
@@ -182,10 +182,11 @@ class Builder implements BuilderInterface
     public function getMatcher()
     {
         if (!$this->matcher) {
-            $cacheCode    = $this->buildMatcherCache();
+
             $matcherCache = new ConfigCache($this->getAbsoluteCachePath(), $this->isDebug());
 
             if (!$matcherCache->isFresh()) {
+                $cacheCode = $this->buildMatcherCache();
                 $resources = [];
 
                 foreach ($this->cacheResources as $resource) {


### PR DESCRIPTION
Resources files are always parsed even if the matcher is in cache