### PR TITLE
Fix symfony 3 compatibilities

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/Resources/config/services.yml
+++ b/src/M6Web/Bundle/LogBridgeBundle/Resources/config/services.yml
@@ -18,49 +18,49 @@ parameters:
 
 services:
     m6web_log_bridge.logger:
-        class: %m6web_log_bridge.logger.class%
+        class: "%m6web_log_bridge.logger.class%"
         arguments:
-            - '@logger'
+            - "@logger"
         tags:
-            - { name: monolog.logger, channel: %m6web_log_bridge.logger.channel% }
+            - { name: monolog.logger, channel: "%m6web_log_bridge.logger.channel%" }
 
     m6web_log_bridge.config_parser:
-        class: %m6web_log_bridge.config_parser.class%
+        class: "%m6web_log_bridge.config_parser.class%"
         arguments:
-            - '@router'
+            - "@router"
 
     m6web_log_bridge.matcher.status.type_manager:
-        class: %m6web_log_bridge.matcher.status.type_manager.class%
+        class: "%m6web_log_bridge.matcher.status.type_manager.class%"
 
     m6web_log_bridge.builder:
-        class: %m6web_log_bridge.builder.class%
+        class: "%m6web_log_bridge.builder.class%"
         arguments:
-            - @m6web_log_bridge.matcher.status.type_manager
-            - %m6web_log_bridge.resources%
-            - %kernel.environment%
+            - "@m6web_log_bridge.matcher.status.type_manager"
+            - "%m6web_log_bridge.resources%"
+            - "%kernel.environment%"
         calls:
-            - [ setDispatcher, [ '@event_dispatcher' ] ]
-            - [ setConfigParser, [ '@m6web_log_bridge.config_parser' ] ]
-            - [ setCacheDir, [ %kernel.cache_dir% ] ]
-            - [ isDebug, [ %kernel.debug% ] ]
-            - [ setMatcherClassName, [ %m6web_log_bridge.matcher_class.name% ] ]
+            - [ setDispatcher, [ "@event_dispatcher" ] ]
+            - [ setConfigParser, [ "@m6web_log_bridge.config_parser" ] ]
+            - [ setCacheDir, [ "%kernel.cache_dir%" ] ]
+            - [ isDebug, [ "%kernel.debug%" ] ]
+            - [ setMatcherClassName, [ "%m6web_log_bridge.matcher_class.name%" ] ]
 
     m6web_log_bridge.matcher:
-        class: %m6web_log_bridge.matcher_proxy.class%
+        class: "%m6web_log_bridge.matcher_proxy.class%"
         arguments:
-            - '@m6web_log_bridge.builder'
+            - "@m6web_log_bridge.builder"
 
     m6web_log_bridge.log_content_formatter:
-        class: %m6web_log_bridge.log_content_formatter.class%
+        class: "%m6web_log_bridge.log_content_formatter.class%"
         arguments:
-            - %kernel.environment%
-            - %m6web_log_bridge.ignore_headers%
-            - %m6web_log_bridge.prefix_key%
+            - "%kernel.environment%"
+            - "%m6web_log_bridge.ignore_headers%"
+            - "%m6web_log_bridge.prefix_key%"
         calls:
-            - [ setTokenStorage, [ '@?security.token_storage' ] ]
+            - [ setTokenStorage, [ "@?security.token_storage" ] ]
 
     m6web_log_bridge.log_content_exception_formatter:
-        class: %m6web_log_bridge.log_content_exception_formatter.class%
+        class: "%m6web_log_bridge.log_content_exception_formatter.class%"
         parent: m6web_log_bridge.log_content_formatter
         calls:
-            - [ setRequestExceptionAttribute, [ %m6web_log_bridge.exception.request_attribute% ] ]
+            - [ setRequestExceptionAttribute, [ "%m6web_log_bridge.exception.request_attribute%" ] ]


### PR DESCRIPTION
Symfony 3 compatibilities :
- Parser YAML was updated, use `"` or `'` is necessary to call service with `@` in DIC 