### PR TITLE
Fix logger service validation

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/CompilerPass/LoggerValidationPass.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/CompilerPass/LoggerValidationPass.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Validates logger service used by the log request listener.
+ */
+class LoggerValidationPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('m6web_log_bridge.logger.service')) {
+            return;
+        }
+
+        $loggerServiceId = $container->getParameter('m6web_log_bridge.logger.service');
+        $loggerClass = $container->findDefinition($loggerServiceId)->getClass();
+
+        // If $loggerClass is not a valid namespace but a container parameter
+        if (preg_match("/^%[\w\.]+%$/", $loggerClass)) {
+            $loggerClassParameter = substr($loggerClass, 1, -1);
+            $loggerClass = $container->getParameter($loggerClassParameter);
+        }
+
+        if (!in_array('Psr\Log\LoggerInterface', class_implements($loggerClass))) {
+            throw new \InvalidArgumentException(sprintf('Class "%s" must be implement "Psr\Log\LoggerInterface"', $loggerClass));
+        }
+    }
+}

--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
@@ -50,35 +50,7 @@ class M6WebLogBridgeExtension extends Extension
                 );
         }
 
-        $this->validateLogger($container, $config['logger']);
         $this->loadRequestListener($container);
-    }
-
-    /**
-     * validateLogger
-     *
-     * @param ContainerBuilder $container    Container
-     * @param array            $loggerConfig Logger configuration
-     *
-     * @throws \Exception Class logger must be implement "Psr\Log\LoggerInterface"
-     *
-     * @return bool
-     */
-    protected function validateLogger(ContainerBuilder $container, $loggerConfig)
-    {
-        $loggerClass = $container->getDefinition($loggerConfig['service'])->getClass();
-
-        // If $loggerClass is not a valid namespace but a container parameter
-        if (preg_match("/^%[\w\.]+%$/", $loggerClass)) {
-            $loggerClassParameter = substr($loggerClass, 1, -1);
-            $loggerClass = $container->getParameter($loggerClassParameter);
-        }
-
-        if (!in_array('Psr\Log\LoggerInterface', class_implements($loggerClass))) {
-            throw new \Exception(sprintf('Class "%s" must be implement "Psr\Log\LoggerInterface"', $loggerClass));
-        }
-
-        return true;
     }
 
     /**

--- a/src/M6Web/Bundle/LogBridgeBundle/M6WebLogBridgeBundle.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/M6WebLogBridgeBundle.php
@@ -2,6 +2,8 @@
 
 namespace M6Web\Bundle\LogBridgeBundle;
 
+use M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass\LoggerValidationPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass\MatcherStatusTypeCompilerPass;
@@ -23,5 +25,6 @@ class M6WebLogBridgeBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new MatcherStatusTypeCompilerPass());
+        $container->addCompilerPass(new LoggerValidationPass(), PassConfig::TYPE_OPTIMIZE);
     }
 }


### PR DESCRIPTION
This validation cannot be done within the DIC extension, because at compile time `MergeExtensionConfigurationPass` creates a new `ContainerBuilder` instance for each extension. Hence, when passing via configuration a specific service from outside this bundle, this service
cannot be found because it's not created by the extension.

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
  You have requested a non-existent service "my_logger_service".
```

This patch moves the validation logic in a new compiler pass. This pass is triggered at Optimize step on purpose, in order to have container parameter placeholders resolved.