### PR TITLE
allow partial ExceptionFormatter override

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php
@@ -39,7 +39,7 @@ class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterI
         if ($request->attributes->has($this->requestExceptionAttribute)) {
             $exception = $request->attributes->get($this->requestExceptionAttribute);
 
-            $logContent .= self::getExceptionTrace($exception);
+            $logContent .= $this->getExceptionTrace($exception);
         }
 
         return $logContent;
@@ -53,10 +53,10 @@ class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterI
      */
     protected function getExceptionTrace(\Exception $exception, $level = 1)
     {
-        $exceptionTrace = self::formatException($exception, $level);
+        $exceptionTrace = $this->formatException($exception, $level);
 
         if (($previousException = $exception->getPrevious()) !== null) {
-            $exceptionTrace .= self::getExceptionTrace($previousException, $level + 1);
+            $exceptionTrace .= $this->getExceptionTrace($previousException, $level + 1);
         }
 
         return $exceptionTrace;


### PR DESCRIPTION
## Why
Because of the `self::` calls, we can't extend the ExceptionFormatter class to reuse some of its methods.

This is really useful when we just want to override the exception rendering, with:

```yaml
m6_web_log_bridge:
    content_formatter: 'app.exception_formatter'
    exception:
        log: true

services:
    app.exception_formatter:
        class: 'AppBundle\ExceptionFormatter'
        parent: 'm6web_log_bridge.log_content_exception_formatter'
```

```php
<?php

namespace AppBundle;

use M6Web\Bundle\LogBridgeBundle\Formatter\ExceptionFormatter as BaseExceptionFormatter;

class ExceptionFormatter extends BaseExceptionFormatter
{
    protected function formatException(\Exception $exception, $level = 1)
    {
        return 'I prefer to format my exceptions just like this :D';
    }
}

```

## How
Use `$this->` instead of `self::`