### PR TITLE
Test "method" as empty since default value is now an empty array.

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Dumper/PhpMatcherDumper.php
@@ -363,7 +363,7 @@ EOF;
         $compiled = [];
         $prefix = is_null($filter->getRoute()) ? 'all' : $filter->getRoute();
 
-        if (is_null($filter->getMethod())) {
+        if (empty($filter->getMethod())) {
             $prefix = sprintf('%s.all', $prefix, $filter->getMethod());
             $compiledKeys = $this->compileFilterStatus($prefix, $filter);
         } else {


### PR DESCRIPTION
## Why
Since the configuration change, the default value for method is an empty array instead of a null value, meaning the filters are not generated.

## How
Use **empty** to check the **method** value.


