### PR TITLE
Fix deprecated getException on Event

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogExceptionListener.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogExceptionListener.php
@@ -29,8 +29,14 @@ class LogExceptionListener
      */
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
+        if (method_exists($event, 'getThrowable')) {
+            $exception = $event->getThrowable();
+        } else {
+            $exception = $event->getException();
+        }
+
         $request = $event->getRequest();
         $request->setRequestFormat('json');
-        $request->attributes->add([$this->requestExceptionAttribute => $event->getException()]);
+        $request->attributes->add([$this->requestExceptionAttribute => $exception]);
     }
 }


### PR DESCRIPTION
Fix the following deprecated :

> The "Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent::getException()" method is deprecated since Symfony 4.4, use "getThrowable()" instead.

The `if (method_exists($event, 'getThrowable')) {` keep compatibility with Symfony < 4.4.