### PR TITLE
Fix deprecated on tree builder root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-language: php
 
 php:
-  - 5.6
-  - 7
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
   - phpenv config-rm xdebug.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-
+language: php
 php:
   - 7.1
   - 7.2

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "minimum-stability" : "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1.3",
         "symfony/config": "^4.2",
         "symfony/yaml": "~2.3 || ~3.0 || ~4.0",
         "symfony/routing": "~2.3 || ~3.0 || ~4.0",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=5.6",
+        "symfony/config": "^4.2",
         "symfony/yaml": "~2.3 || ~3.0 || ~4.0",
         "symfony/routing": "~2.3 || ~3.0 || ~4.0",
         "symfony/expression-language": "~2.3 || ~3.0 || ~4.0",

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/Configuration.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/Configuration.php
@@ -7,14 +7,10 @@ namespace M6Web\Bundle\LogBridgeBundle\Config;
  */
 class Configuration
 {
-    /**
-     * @var FilterCollection
-     */
+    /** @var FilterCollection */
     private $filters;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $activeFilters;
 
     /**
@@ -28,8 +24,6 @@ class Configuration
 
     /**
      * setActiveFilters
-     *
-     * @param array $activeFilters
      *
      * @return Configuration
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/Filter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/Filter.php
@@ -7,34 +7,22 @@ namespace M6Web\Bundle\LogBridgeBundle\Config;
  */
 class Filter
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $name;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $route;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     private $method;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     private $status;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     private $level;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $options;
 
     /**
@@ -160,8 +148,6 @@ class Filter
 
     /**
      * set filter options
-     *
-     * @param array $options
      *
      * @return Filter
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/FilterCollection.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/FilterCollection.php
@@ -7,25 +7,17 @@ namespace M6Web\Bundle\LogBridgeBundle\Config;
  */
 class FilterCollection implements \Iterator
 {
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $iterator;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $keys;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $values;
 
     /**
      * __construct
-     *
-     * @param array $items
      *
      * @internal param array $filters Filters
      */
@@ -42,8 +34,6 @@ class FilterCollection implements \Iterator
 
     /**
      * add
-     *
-     * @param Filter $item
      *
      * @internal param \M6Web\Bundle\LogBridgeBundle\Config\Filter $filter Filter
      *

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/FilterParser.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/FilterParser.php
@@ -12,9 +12,7 @@ class FilterParser
 {
     const DEFAULT_LEVEL = LogLevel::INFO;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $allowedLevels = [
         LogLevel::EMERGENCY,
         LogLevel::ALERT,
@@ -26,14 +24,10 @@ class FilterParser
         LogLevel::DEBUG,
     ];
 
-    /**
-     * @var RouterInterface
-     */
+    /** @var RouterInterface */
     protected $router;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $filterClass;
 
     /**
@@ -212,12 +206,7 @@ class FilterParser
             !$reflection->isInstantiable()
              || !$reflection->isSubclassOf('M6Web\Bundle\LogBridgeBundle\Config\Filter')
         ) {
-            throw new \RuntimeException(
-                sprintf(
-                    '"%s" is not instantiable or is not a subclass of "M6Web\Bundle\LogBridgeBundle\Config\Filter"',
-                    $filterClass
-                )
-            );
+            throw new \RuntimeException(sprintf('"%s" is not instantiable or is not a subclass of "M6Web\Bundle\LogBridgeBundle\Config\Filter"', $filterClass));
         }
 
         $this->filterClass = $filterClass;

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/Parser.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/Parser.php
@@ -9,14 +9,10 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class Parser
 {
-    /**
-     * @var RouterInterface
-     */
+    /** @var RouterInterface */
     private $router;
 
-    /**
-     * @var FilterParser
-     */
+    /** @var FilterParser */
     private $filterParser;
 
     /**
@@ -51,8 +47,6 @@ class Parser
     /**
      * parse
      * Load Log Request filter configuration
-     *
-     * @param array $params
      *
      * @internal param array $config Config
      *

--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/CompilerPass/MatcherStatusTypeCompilerPass.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/CompilerPass/MatcherStatusTypeCompilerPass.php
@@ -2,8 +2,8 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -11,9 +11,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class MatcherStatusTypeCompilerPass implements CompilerPassInterface
 {
-    /**
-     * @param ContainerBuilder $container
-     */
     public function process(ContainerBuilder $container)
     {
         if (!$container->has('m6web_log_bridge.matcher.status.type_manager')) {

--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('m6web_log_bridge');
+        $treeBuilder = new TreeBuilder('m6web_log_bridge');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
@@ -2,12 +2,12 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration

--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/BuilderEvent.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/BuilderEvent.php
@@ -2,22 +2,18 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\EventDispatcher;
 
-use Symfony\Component\EventDispatcher\Event;
 use M6Web\Bundle\LogBridgeBundle\Matcher\BuilderInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * BuilderEvent
  */
 class BuilderEvent extends Event
 {
-    /**
-     * @var BuilderInterface
-     */
+    /** @var BuilderInterface */
     private $builder;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $config;
 
     /**

--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogExceptionListener.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogExceptionListener.php
@@ -9,9 +9,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
  */
 class LogExceptionListener
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $requestExceptionAttribute;
 
     /**
@@ -24,8 +22,6 @@ class LogExceptionListener
 
     /**
      * React to an exception to give error message to log bridge
-     *
-     * @param GetResponseForExceptionEvent $event
      */
     public function onKernelException(GetResponseForExceptionEvent $event)
     {

--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php
@@ -2,34 +2,26 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\EventDispatcher;
 
-use Psr\Log\LoggerInterface;
-use M6Web\Bundle\LogBridgeBundle\Matcher\MatcherInterface;
 use M6Web\Bundle\LogBridgeBundle\Formatter\FormatterInterface;
+use M6Web\Bundle\LogBridgeBundle\Matcher\MatcherInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * LogRequestListener
  */
 class LogRequestListener
 {
-    /**
-     * @var LoggerInterface
-     */
+    /** @var LoggerInterface */
     protected $logger;
 
-    /**
-     * @var MatcherInterface
-     */
+    /** @var MatcherInterface */
     protected $matcher;
 
-    /**
-     * @var FormatterInterface
-     */
+    /** @var FormatterInterface */
     protected $contentFormatter;
 
     /**
      * Construct
-     *
-     * @param FormatterInterface $contentFormatter
      *
      * @internal param \Psr\Log\LoggerInterface $logger Logger
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/Formatter/DefaultFormatter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Formatter/DefaultFormatter.php
@@ -11,24 +11,16 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class DefaultFormatter implements FormatterInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $environment;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $ignoreHeaders;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $prefixKey;
 
-    /**
-     * @var TokenStorageInterface
-     */
+    /** @var TokenStorageInterface */
     protected $tokenStorage;
 
     /**
@@ -48,8 +40,6 @@ class DefaultFormatter implements FormatterInterface
 
     /**
      * Format parameters as tree
-     *
-     * @param array $parameters
      *
      * @return string
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php
@@ -10,9 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $requestExceptionAttribute;
 
     /**
@@ -46,8 +44,7 @@ class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterI
     }
 
     /**
-     * @param \Exception $exception
-     * @param int        $level
+     * @param int $level
      *
      * @return string
      */
@@ -63,8 +60,7 @@ class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterI
     }
 
     /**
-     * @param \Exception $exception
-     * @param int        $level
+     * @param int $level
      *
      * @return string
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/M6WebLogBridgeBundle.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/M6WebLogBridgeBundle.php
@@ -3,10 +3,10 @@
 namespace M6Web\Bundle\LogBridgeBundle;
 
 use M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass\LoggerValidationPass;
+use M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass\MatcherStatusTypeCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass\MatcherStatusTypeCompilerPass;
 
 /**
  * Class M6WebLogBridgeBundle
@@ -15,8 +15,6 @@ class M6WebLogBridgeBundle extends Bundle
 {
     /**
      * Build bundle
-     *
-     * @param ContainerBuilder $container
      */
     public function build(ContainerBuilder $container)
     {

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Builder.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Builder.php
@@ -2,69 +2,47 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\Matcher;
 
-use Symfony\Component\Config\ConfigCache;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use M6Web\Bundle\LogBridgeBundle\Config\Parser as ConfigParser;
 use M6Web\Bundle\LogBridgeBundle\Matcher\Status\TypeManager as StatusTypeManager;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Builder
  */
 class Builder implements BuilderInterface
 {
-    /**
-     * @var StatusTypeManager
-     */
+    /** @var StatusTypeManager */
     private $statusTypeManager;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $environment;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $cacheResources;
 
-    /**
-     * @var EventDispatcherInterface
-     */
+    /** @var EventDispatcherInterface */
     private $dispatcher;
 
-    /**
-     * @var Loader
-     */
+    /** @var Loader */
     private $configParser;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $debug;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $cacheDir;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $matcherClassName;
 
-    /**
-     * @var MatcherInterface
-     */
+    /** @var MatcherInterface */
     private $matcher;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $filters;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $activeFilters;
 
     /**
@@ -186,8 +164,6 @@ class Builder implements BuilderInterface
 
     /**
      * setDispatcher
-     *
-     * @param EventDispatcherInterface $dispatcher
      *
      * @return Builder
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Dumper/PhpMatcherDumper.php
@@ -2,11 +2,11 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\Matcher\Dumper;
 
-use Psr\Log\LogLevel;
 use M6Web\Bundle\LogBridgeBundle\Config\Configuration;
-use M6Web\Bundle\LogBridgeBundle\Config\FilterCollection;
 use M6Web\Bundle\LogBridgeBundle\Config\Filter;
+use M6Web\Bundle\LogBridgeBundle\Config\FilterCollection;
 use M6Web\Bundle\LogBridgeBundle\Matcher\Status\TypeManager as StatusTypeManager;
+use Psr\Log\LogLevel;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
@@ -15,9 +15,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  */
 class PhpMatcherDumper
 {
-    /**
-     * @var StatusTypeManager
-     */
+    /** @var StatusTypeManager */
     private $statusTypeManager;
 
     /**
@@ -32,9 +30,6 @@ class PhpMatcherDumper
 
     /**
      * dump
-     *
-     * @param Configuration $configuration
-     * @param array         $options
      *
      * @return string
      */
@@ -252,8 +247,6 @@ EOF;
     /**
      * generateMatchList
      *
-     * @param Configuration $configuration
-     *
      * @return string
      */
     private function generateMatchList(Configuration $configuration)
@@ -407,8 +400,6 @@ EOF;
 
     /**
      * parseStatus
-     *
-     * @param array $filterStatusList
      *
      * @throws \Exception status not allowed in log bridge configuration filters
      *

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/MatcherProxy.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/MatcherProxy.php
@@ -9,14 +9,10 @@ use Psr\Log\LogLevel;
  */
 class MatcherProxy implements MatcherInterface
 {
-    /**
-     * @var BuilderInterface
-     */
+    /** @var BuilderInterface */
     private $builder;
 
-    /**
-     * @var MatcherInterface
-     */
+    /** @var MatcherInterface */
     private $matcher;
 
     /**

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Status/Type/AbstractType.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Status/Type/AbstractType.php
@@ -7,9 +7,7 @@ namespace M6Web\Bundle\LogBridgeBundle\Matcher\Status\Type;
  */
 abstract class AbstractType implements TypeInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $pattern;
 
     /**
@@ -42,10 +40,7 @@ abstract class AbstractType implements TypeInterface
         $status = $this->transform($config);
 
         if (!is_array($status)) {
-            throw new \Exception(
-                sprintf('"transform" method must be return an array in class "%s"', get_class($this)),
-                500
-            );
+            throw new \Exception(sprintf('"transform" method must be return an array in class "%s"', get_class($this)), 500);
         }
 
         return $status;

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Status/TypeManager.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Status/TypeManager.php
@@ -9,9 +9,7 @@ use M6Web\Bundle\LogBridgeBundle\Matcher\Status\Type\TypeInterface;
  */
 class TypeManager
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $types = [];
 
     /**
@@ -26,8 +24,6 @@ class TypeManager
 
     /**
      * Add a type
-     *
-     * @param TypeInterface $type
      *
      * @return $this
      */
@@ -45,8 +41,6 @@ class TypeManager
     /**
      * Remove a type
      *
-     * @param TypeInterface $typeToRemove
-     *
      * @return $this
      */
     public function removeType(TypeInterface $typeToRemove)
@@ -63,8 +57,6 @@ class TypeManager
 
     /**
      * Check if type pass is already record as type
-     *
-     * @param TypeInterface $typeToCheck
      *
      * @return bool
      */


### PR DESCRIPTION
Fix the following deprecation :

> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
> 
> The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "m6web_log_bridge" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.

See https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php#L30