### PR TITLE
Restored CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 before_script:
   - phpenv config-rm xdebug.ini
   - wget http://getcomposer.org/composer.phar
-  - php -d memory_limit=2G composer.phar install
+  - php -d memory_limit=4G composer.phar install
 
 script:
   - bin/atoum

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/Configuration.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/Configuration.php
@@ -29,8 +29,6 @@ class Configuration
     /**
      * setActiveFilters
      *
-     * @param array $activeFilters
-     *
      * @return Configuration
      */
     public function setActiveFilters(array $activeFilters)

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/Filter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/Filter.php
@@ -161,8 +161,6 @@ class Filter
     /**
      * set filter options
      *
-     * @param array $options
-     *
      * @return Filter
      */
     public function setOptions(array $options)

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/FilterCollection.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/FilterCollection.php
@@ -25,8 +25,6 @@ class FilterCollection implements \Iterator
     /**
      * __construct
      *
-     * @param array $items
-     *
      * @internal param array $filters Filters
      */
     public function __construct(array $items = [])
@@ -42,8 +40,6 @@ class FilterCollection implements \Iterator
 
     /**
      * add
-     *
-     * @param Filter $item
      *
      * @internal param \M6Web\Bundle\LogBridgeBundle\Config\Filter $filter Filter
      *

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/FilterParser.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/FilterParser.php
@@ -212,12 +212,7 @@ class FilterParser
             !$reflection->isInstantiable()
              || !$reflection->isSubclassOf('M6Web\Bundle\LogBridgeBundle\Config\Filter')
         ) {
-            throw new \RuntimeException(
-                sprintf(
-                    '"%s" is not instantiable or is not a subclass of "M6Web\Bundle\LogBridgeBundle\Config\Filter"',
-                    $filterClass
-                )
-            );
+            throw new \RuntimeException(sprintf('"%s" is not instantiable or is not a subclass of "M6Web\Bundle\LogBridgeBundle\Config\Filter"', $filterClass));
         }
 
         $this->filterClass = $filterClass;

--- a/src/M6Web/Bundle/LogBridgeBundle/Config/Parser.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Config/Parser.php
@@ -52,8 +52,6 @@ class Parser
      * parse
      * Load Log Request filter configuration
      *
-     * @param array $params
-     *
      * @internal param array $config Config
      *
      * @return Configuration

--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/CompilerPass/MatcherStatusTypeCompilerPass.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/CompilerPass/MatcherStatusTypeCompilerPass.php
@@ -2,8 +2,8 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -11,9 +11,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class MatcherStatusTypeCompilerPass implements CompilerPassInterface
 {
-    /**
-     * @param ContainerBuilder $container
-     */
     public function process(ContainerBuilder $container)
     {
         if (!$container->has('m6web_log_bridge.matcher.status.type_manager')) {

--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
@@ -2,12 +2,12 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration

--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/BuilderEvent.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/BuilderEvent.php
@@ -2,8 +2,8 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\EventDispatcher;
 
-use Symfony\Component\EventDispatcher\Event;
 use M6Web\Bundle\LogBridgeBundle\Matcher\BuilderInterface;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * BuilderEvent

--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogExceptionListener.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogExceptionListener.php
@@ -24,8 +24,6 @@ class LogExceptionListener
 
     /**
      * React to an exception to give error message to log bridge
-     *
-     * @param GetResponseForExceptionEvent $event
      */
     public function onKernelException(GetResponseForExceptionEvent $event)
     {

--- a/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php
@@ -2,9 +2,9 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\EventDispatcher;
 
-use Psr\Log\LoggerInterface;
-use M6Web\Bundle\LogBridgeBundle\Matcher\MatcherInterface;
 use M6Web\Bundle\LogBridgeBundle\Formatter\FormatterInterface;
+use M6Web\Bundle\LogBridgeBundle\Matcher\MatcherInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * LogRequestListener
@@ -28,8 +28,6 @@ class LogRequestListener
 
     /**
      * Construct
-     *
-     * @param FormatterInterface $contentFormatter
      *
      * @internal param \Psr\Log\LoggerInterface $logger Logger
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/Formatter/DefaultFormatter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Formatter/DefaultFormatter.php
@@ -49,8 +49,6 @@ class DefaultFormatter implements FormatterInterface
     /**
      * Format parameters as tree
      *
-     * @param array $parameters
-     *
      * @return string
      */
     protected function formatParameters(array $parameters)

--- a/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php
@@ -46,8 +46,7 @@ class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterI
     }
 
     /**
-     * @param \Exception $exception
-     * @param int        $level
+     * @param int $level
      *
      * @return string
      */
@@ -63,8 +62,7 @@ class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterI
     }
 
     /**
-     * @param \Exception $exception
-     * @param int        $level
+     * @param int $level
      *
      * @return string
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/M6WebLogBridgeBundle.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/M6WebLogBridgeBundle.php
@@ -3,10 +3,10 @@
 namespace M6Web\Bundle\LogBridgeBundle;
 
 use M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass\LoggerValidationPass;
+use M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass\MatcherStatusTypeCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use M6Web\Bundle\LogBridgeBundle\DependencyInjection\CompilerPass\MatcherStatusTypeCompilerPass;
 
 /**
  * Class M6WebLogBridgeBundle
@@ -15,8 +15,6 @@ class M6WebLogBridgeBundle extends Bundle
 {
     /**
      * Build bundle
-     *
-     * @param ContainerBuilder $container
      */
     public function build(ContainerBuilder $container)
     {

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Builder.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Builder.php
@@ -2,10 +2,10 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\Matcher;
 
-use Symfony\Component\Config\ConfigCache;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use M6Web\Bundle\LogBridgeBundle\Config\Parser as ConfigParser;
 use M6Web\Bundle\LogBridgeBundle\Matcher\Status\TypeManager as StatusTypeManager;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Builder
@@ -186,8 +186,6 @@ class Builder implements BuilderInterface
 
     /**
      * setDispatcher
-     *
-     * @param EventDispatcherInterface $dispatcher
      *
      * @return Builder
      */

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Dumper/PhpMatcherDumper.php
@@ -2,11 +2,11 @@
 
 namespace M6Web\Bundle\LogBridgeBundle\Matcher\Dumper;
 
-use Psr\Log\LogLevel;
 use M6Web\Bundle\LogBridgeBundle\Config\Configuration;
-use M6Web\Bundle\LogBridgeBundle\Config\FilterCollection;
 use M6Web\Bundle\LogBridgeBundle\Config\Filter;
+use M6Web\Bundle\LogBridgeBundle\Config\FilterCollection;
 use M6Web\Bundle\LogBridgeBundle\Matcher\Status\TypeManager as StatusTypeManager;
+use Psr\Log\LogLevel;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
@@ -32,9 +32,6 @@ class PhpMatcherDumper
 
     /**
      * dump
-     *
-     * @param Configuration $configuration
-     * @param array         $options
      *
      * @return string
      */
@@ -252,8 +249,6 @@ EOF;
     /**
      * generateMatchList
      *
-     * @param Configuration $configuration
-     *
      * @return string
      */
     private function generateMatchList(Configuration $configuration)
@@ -407,8 +402,6 @@ EOF;
 
     /**
      * parseStatus
-     *
-     * @param array $filterStatusList
      *
      * @throws \Exception status not allowed in log bridge configuration filters
      *

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Status/Type/AbstractType.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Status/Type/AbstractType.php
@@ -42,10 +42,7 @@ abstract class AbstractType implements TypeInterface
         $status = $this->transform($config);
 
         if (!is_array($status)) {
-            throw new \Exception(
-                sprintf('"transform" method must be return an array in class "%s"', get_class($this)),
-                500
-            );
+            throw new \Exception(sprintf('"transform" method must be return an array in class "%s"', get_class($this)), 500);
         }
 
         return $status;

--- a/src/M6Web/Bundle/LogBridgeBundle/Matcher/Status/TypeManager.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Matcher/Status/TypeManager.php
@@ -27,8 +27,6 @@ class TypeManager
     /**
      * Add a type
      *
-     * @param TypeInterface $type
-     *
      * @return $this
      */
     public function addType(TypeInterface $type)
@@ -44,8 +42,6 @@ class TypeManager
 
     /**
      * Remove a type
-     *
-     * @param TypeInterface $typeToRemove
      *
      * @return $this
      */
@@ -63,8 +59,6 @@ class TypeManager
 
     /**
      * Check if type pass is already record as type
-     *
-     * @param TypeInterface $typeToCheck
      *
      * @return bool
      */


### PR DESCRIPTION
1/ To fix following error on CI

```
Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 86 bytes) in phar:///home/travis/build/M6Web/LogBridgeBundle/composer.phar/src/Composer/DependencyResolver/RuleSet.php on line 90

The command "php -d memory_limit=2G composer.phar install" failed and exited with 255 during .
```

2/ Fixing style guide `bin/php-cs-fixer fix`