### PR TITLE
feat: allow loading without http router

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
@@ -51,7 +51,9 @@ class M6WebLogBridgeExtension extends Extension
                 );
         }
 
-        $this->loadRequestListener($container);
+        if ($container->has('router')) {
+            $this->loadRequestListener($container);
+        }
     }
 
     /**


### PR DESCRIPTION
If symfony's router is disabled, this bundle cannot load because of dependency on the request events.
This change tests for it before loading the event listener.