### PR TITLE
fix: use Throwable instead of Exception in formatter

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php
@@ -48,7 +48,7 @@ class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterI
      *
      * @return string
      */
-    protected function getExceptionTrace(\Exception $exception, $level = 1)
+    protected function getExceptionTrace(\Throwable $exception, $level = 1)
     {
         $exceptionTrace = $this->formatException($exception, $level);
 
@@ -64,7 +64,7 @@ class ExceptionFormatter extends DefaultFormatter implements ExceptionFormatterI
      *
      * @return string
      */
-    protected function formatException(\Exception $exception, $level = 1)
+    protected function formatException(\Throwable $exception, $level = 1)
     {
         return
             "\nException class : \n------------------------\n".get_class($exception)."\n".

--- a/src/M6Web/Bundle/LogBridgeBundle/Tests/Units/Formatter/ExceptionFormatter.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Tests/Units/Formatter/ExceptionFormatter.php
@@ -149,4 +149,25 @@ class ExceptionFormatter extends atoum
                 ->contains($exception3->getTraceAsString())
         ;
     }
+
+    public function testTypeErrorException()
+    {
+        $request = new Request();
+        $exception = new \TypeError('Test: TypeError exception thrown.');
+
+        $this
+            ->given(
+                $request->attributes->add([$this->requestExceptionAttribute => $exception])
+            )
+            ->if($provider = $this->createProvider())
+            ->then
+            ->object($provider->setTokenStorage($this->getMockedTokenStorage()))
+            ->isInstanceOf('M6Web\Bundle\LogBridgeBundle\Formatter\ExceptionFormatter')
+            ->string($provider->getLogContent($request, new Response('Body content response'), []))
+            ->contains('Exception message (1) :')
+            ->contains($exception->getMessage())
+            ->contains('Exception trace (1) :')
+            ->contains($exception->getTraceAsString())
+        ;
+    }
 }


### PR DESCRIPTION
### Why: 
```php
TypeError
HTTP 500 Internal Server Error
Argument 1 passed to M6Web\Bundle\LogBridgeBundle\Formatter\ExceptionFormatter::getExceptionTrace() must be an instance of Exception, instance of TypeError given, called in .../vendor/m6web/log-bridge-bundle/src/M6Web/Bundle/LogBridgeBundle/Formatter/ExceptionFormatter.php on line 40
```
When [`TypeError`](https://www.php.net/manual/en/class.typeerror.php) is thrown, formatter does'nt support it

### How

`TypeError`,  and `Exceptions` both extend `Throwable` however `TypeError` is not extended from `Exception`.

Therefore, `ExceptionFormatter` must accept an object of Type `Throwable` in order to accept `TypeError`.