### PR TITLE
fix(formatter): doc for method response

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/Formatter/FormatterInterface.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/Formatter/FormatterInterface.php
@@ -24,7 +24,7 @@ interface FormatterInterface
      * @param Response $response Response service
      * @param array    $options  Request options
      *
-     * @return string
+     * @return array
      */
     public function getLogContext(Request $request, Response $response, array $options);
 }


### PR DESCRIPTION
Context should be an array and not a string :
https://github.com/M6Web/LogBridgeBundle/blob/623a8dd7469dec70d54de6fccdda369ad43225d2/src/M6Web/Bundle/LogBridgeBundle/EventDispatcher/LogRequestListener.php#L53
https://github.com/M6Web/LogBridgeBundle/blob/623a8dd7469dec70d54de6fccdda369ad43225d2/src/M6Web/Bundle/LogBridgeBundle/Tests/Units/Formatter/DefaultFormatter.php#L76