### PR TITLE
feat(symfony): add Symfony 5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Symfony Bundle to log Request/Response with Monolog. 
 
-**NOTE:** Require `Symfony >= 2.6` since version 3.0. For previsous version of symfony use the `~2.2` release.
-
+**NOTE:** The actual version of this bundle support `Symfony >= 4.4`.
+If you need support for older versions, please use `~7.0` release.
 
 ## Features
 

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.1.3",
-        "symfony/config": "^4.2",
-        "symfony/yaml": "~2.3 || ~3.0 || ~4.0",
-        "symfony/routing": "~2.3 || ~3.0 || ~4.0",
-        "symfony/expression-language": "~2.3 || ~3.0 || ~4.0",
-        "symfony/security": "~2.3 || ~3.0 || ~4.0"
+        "symfony/config": "^4.4|^5.0",
+        "symfony/yaml": "^4.4|^5.0",
+        "symfony/routing": "^4.4|^5.0",
+        "symfony/expression-language": "^4.4|^5.0",
+        "symfony/security-core": "^4.4|^5.0"
     },
     "require-dev": {
         "atoum/atoum-bundle": "~1.0",


### PR DESCRIPTION
Add Symfony 5 compatibility.

⚠️ Breaking change, the `symfony/security` has been split into severable package.
So its usage has been replaced by `symfony/security-core`.