### PR TITLE
Doc: run tests with code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,5 +231,5 @@ If you prefer to use your own formatter, you will be able to read exceptions dir
 You can run the unit tests with the following command:
 
 ```
-    php bin/atoum -d src/M6Web/Bundle/LogBridgeBundle/Tests/Units
+    XDEBUG_MODE=coverage php bin/atoum -d src/M6Web/Bundle/LogBridgeBundle/Tests/Units
 ```

--- a/README.md
+++ b/README.md
@@ -231,5 +231,5 @@ If you prefer to use your own formatter, you will be able to read exceptions dir
 You can run the unit tests with the following command:
 
 ```
-    XDEBUG_MODE=coverage php bin/atoum -d src/M6Web/Bundle/LogBridgeBundle/Tests/Units
+    make test
 ```


### PR DESCRIPTION
Without code coverage, 

```
Failure (17 tests, 32/32 methods, 0 void method, 0 skipped method, 0 uncompleted method, 0 failure, 32 errors, 0 exception)!
> There are 32 errors:

=> M6Web\Bundle\LogBridgeBundle\Tests\Units\Config\Configuration::testConfiguration():
==> Error E_WARNING in xxxx/vendor/atoum/atoum/classes/test.php on line 1344, generated by file xxxxe/vendor/atoum/atoum/classes/test.php on line 1344:
Code coverage needs to be enabled in php.ini by setting 'xdebug.mode' to 'coverage'

=> M6Web\Bundle\LogBridgeBundle\Tests\Units\Config\Filter::testFilter():
==> Error E_WARNING in xxxx/vendor/atoum/atoum/classes/test.php on line 1344, generated by file xxx/vendor/atoum/atoum/classes/test.php on line 1344:
Code coverage needs to be enabled in php.ini by setting 'xdebug.mode' to 'coverage'

....
```