### PR TITLE
feat: allow loading without http router

### DIFF
--- a/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
+++ b/src/M6Web/Bundle/LogBridgeBundle/DependencyInjection/M6WebLogBridgeExtension.php
@@ -53,7 +53,9 @@ class M6WebLogBridgeExtension extends Extension
                 );
         }
 
-        $this->loadRequestListener($container);
+        if ($container->has('router')) {
+            $this->loadRequestListener($container);
+        }
     }
 
     protected function loadRequestListener(ContainerBuilder $container): void


### PR DESCRIPTION
This bundle is used with a Symfony project that does not have the router. This feat allow to use it without the HTTP router.